### PR TITLE
Update list of supported video hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,13 @@ A Userscript that skips countdowns and intersitial loading pages on WatchSeries 
     - seriesfree.to
     - swatchseries.to
 - Video hosts:
-    - auroravid.to
-    - bitvid.sx
     - daclips.in
     - gorillavid.in
     - movpod.in
-    - nowvideo.to
-    - openload.co
-    - thevideo.cc
-    - thevideo.website
-    - vidup.tv
-    - vidzi.tv
-    - wholecloud.net
+    - flix555.com
+    - idtbox.com
+    - powvideo.net
+    - vshare.eu
 
 # Requesting new video hosts
 

--- a/better-watchseries.user.js
+++ b/better-watchseries.user.js
@@ -7,25 +7,24 @@
 //
 // @namespace    https://github.com/andrewjmetzger/
 // @updateURL        https://openuserjs.org/meta/andrewjmetzger/Better_WatchSeries.meta.js
-// @version      2.7.0
+// @version      2.8.0
 //
 // @grant        unsafeWindow
 // @run-at       document-end
 //
 // @match        *://*.seriesfree.to/*
 // @match        *://*.swatchseries.to/*
-// @match        *://*.auroravid.to/*
-// @match        *://*.bitvid.sx/*
+
 // @match        *://*.daclips.in/*
 // @match        *://*.gorillavid.in/*
 // @match        *://*.movpod.in/*
-// @match        *://*.nowvideo.to/*
+// @match        *://*.flix555.com/*
+// @match        *://*.idtbox.com/*
+// @match        *://*.powvideo.net/*
+
+// @match        *://*.vshare.eu/*
+
 // @match        *://*.openload.co/*
-// @match        *://*.thevideo.cc/*
-// @match        *://*.thevideo.website/*
-// @match        *://*.vidup.tv/*
-// @match        *://*.vidzi.tv/*
-// @match        *://*.wholecloud.net/*
 // ==/UserScript==
 
 /**************************************************
@@ -144,17 +143,13 @@ function clickButtonBySelectorOnHosts(buttonSelector, hosts) {
 }
 
 try {
-  var hosts = ["daclips.in", "gorillavid.in", "movpod.in", "vidup.tv"];
+  var hosts = ["daclips.in", "gorillavid.in", "movpod.in", "flix555.com", "idtbox.com", "powvideo.net"];
   clickButtonByIdOnHosts("btn_download", hosts);
 
-  var hosts = ["thevideo.cc", "thevideo.website"];
-  clickButtonBySelectorOnHosts(
-    "button.btn.btn-lg.btn-primary.bottom-buffer",
-    hosts
-  );
-
-  var hosts = ["auroravid.to", "bitvid.sx", "nowvideo.to", "wholecloud.net"];
-  clickButtonByNameOnHosts("submit", hosts);
+  var hosts = ["vshare.eu"]
+  clickButtonByNameOnHosts("method_free", hosts);
+  
+  
 } catch (err) {
   console.log("Error: Better WatchSeries could not click the button.");
 }


### PR DESCRIPTION
Significantly update the list of supported video hosts.

----

Remove the following defunct hosts:
- auroravid.to
- bitvid.sx
- nowvideo.to
- thevideo.cc
- thevideo.website
- vidup.tv
- vidzi.tv
- wholecloud.net

Add several new hosts:
- flix555.com
- idtbox.com
- powvideo.net
- vshare.eu